### PR TITLE
Trims <!DOCTYPE> from Graphviz output

### DIFF
--- a/lib/jekyll/diagrams/graphviz.rb
+++ b/lib/jekyll/diagrams/graphviz.rb
@@ -55,6 +55,7 @@ module Jekyll
           raise "Non-zero exit status '#{cmd}': #{status}"
         end
 
+        svg.sub! /^<!DOCTYPE(([^>]|\n)*)>(\n?)/, ''
         svg.force_encoding 'UTF-8'
 
         "<div class='graphviz'>#{svg}</div>"


### PR DESCRIPTION
Should solve https://github.com/zhustec/jekyll-diagrams/issues/1 by trimming `<!DOCTYPE>` from the output.