### PR TITLE
Fix graphviz to avoid recration of expensive regexp and allow encoding overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ digraph {
 | `graph_attributes` | unspecified | Set default graph attribute |
 | `node_attributes`  | unspecified | Set default node attribute  |
 | `edge_attributes`  | unspecified | Set default edge attribute  |
+| `encoding`         | utf-8       | Set default SVG encoding    |
 
 **NOTICE:** attributes can be `String`(when just one attribute), `Array` or `Hash`.
 

--- a/lib/jekyll-diagrams/graphviz.rb
+++ b/lib/jekyll-diagrams/graphviz.rb
@@ -8,13 +8,13 @@ module Jekyll
         'E' => 'edge_attributes'
       }.freeze
 
-      @@xml_regex = /^<!DOCTYPE(([^>]|\n)*)>(\n?)/ # avoid expensive recreation of regexp
+      XML_REGEX = /^<\?xml(([^>]|\n)*>\n?){2}/ # avoid expensive recreation of regexp
 
       def render_svg(code, config)
         command = build_command(config)
 
         svg = render_with_stdin_stdout(command, code)
-        svg.sub!(@@xml_regex, '').force_encoding(config.fetch('encoding', 'utf-8')) # allow overriding encoding of output
+        svg.sub!(XML_REGEX, '').force_encoding(config.fetch('encoding', 'utf-8')) # allow overriding encoding of output
       end
 
       def build_command(config)

--- a/lib/jekyll-diagrams/graphviz.rb
+++ b/lib/jekyll-diagrams/graphviz.rb
@@ -8,11 +8,13 @@ module Jekyll
         'E' => 'edge_attributes'
       }.freeze
 
+      @@xml_regex = /^<!DOCTYPE(([^>]|\n)*)>(\n?)/ # avoid expensive recreation of regexp
+
       def render_svg(code, config)
         command = build_command(config)
 
         svg = render_with_stdin_stdout(command, code)
-        svg.sub!(/^<\?xml(([^>]|\n)*>\n?){2}/, '')
+        svg.sub!(@@xml_regex, '').force_encoding(config.fetch('encoding', 'utf-8')) # allow overriding encoding of output
       end
 
       def build_command(config)


### PR DESCRIPTION
Fixes issues reported in https://github.com/zhustec/jekyll-diagrams/issues/9 and https://github.com/zhustec/jekyll-diagrams/issues/11