### PR TITLE
Add the ability to configure a self-chosen plantuml jar, plus configuring where to look for includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /tmp
 *.gem
 *.swp
+
+# macOS system files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -346,6 +346,34 @@ Car -- Person : < owns
 {% endplantuml %}
 ```
 
+#### Configuration
+
+| Config       | Default    | Description                                                                         |
+| ------------ | ---------- | ----------------------------------------------------------------------------------- |
+| `jar_path` | (use internal version) | Path to a custom plantuml jar that should be used to render diagrams. 
+If passed a string, the path is relative to the site base directory. 
+To give an abolute path, set this to a Hash with key "absolute". |
+| `include_path` | (no include path set) | Path to the base directry for files included in diagrams, relative to the site base directory. |
+
+##### Configuration example
+
+Referencing a jar file relative to the site dir:
+```yaml
+jekyll-diagrams:
+  plantuml: 
+    include_path: _plantuml/includes
+    jar_path: _plantuml/plantuml.1.2020.19.jar
+```
+
+Using an abolute path to the plantuml jar file, no include base dir set:
+```yaml
+jekyll-diagrams:
+  plantuml: 
+    jar_path: 
+      absolute: /somewhere/on/your/system/plantuml.jar
+```
+
+
 ### State Machine Cat
 
 #### Prerequisites

--- a/lib/jekyll-diagrams/plantuml/renderer.rb
+++ b/lib/jekyll-diagrams/plantuml/renderer.rb
@@ -3,7 +3,11 @@
 module Jekyll
   module Diagrams
     class PlantUMLRenderer < BasicRenderer
+      DEFAULT_PLANTUML_JAR = 'plantuml.1.2020.1.jar'
+
       XML_REGEX = /^<\?xml([^>]|\n)*>\n?/.freeze
+      INCLUDE_PATH_CONFIG_KEY = "include_path"
+      PLANTUML_JAR_CONFIG_KEY = "jar_path"
 
       def render_svg(code, config)
         command = build_command(config)
@@ -12,11 +16,30 @@ module Jekyll
         svg.sub!(XML_REGEX, '')
       end
 
-      def build_command(_config)
-        jar = Utils.vendor_path('plantuml.1.2020.1.jar')
-
-        options = +Utils.run_jar(jar)
+      def build_command(config)
+        jar = if config.has_key? PLANTUML_JAR_CONFIG_KEY
+          if config[PLANTUML_JAR_CONFIG_KEY].is_a? String
+            base_dir = Jekyll.configuration({})['source']
+            File.expand_path(File.join(base_dir,config[PLANTUML_JAR_CONFIG_KEY]))
+          else
+            File.expand_path(config[PLANTUML_JAR_CONFIG_KEY]["absolute"])
+          end
+        else
+          Utils.vendor_path(DEFAULT_PLANTUML_JAR)
+        end
+        options = +Utils.run_jar(jar, build_jvm_args(config))
         options << ' -tsvg -pipe'
+      end
+
+      private
+
+      def build_jvm_args(config)
+        if config.has_key? INCLUDE_PATH_CONFIG_KEY
+          base_dir = Jekyll.configuration({})['source']
+           {"plantuml.include.path" => File.join(base_dir,config[INCLUDE_PATH_CONFIG_KEY])}
+        else
+          {}
+        end
       end
     end
   end

--- a/lib/jekyll-diagrams/utils.rb
+++ b/lib/jekyll-diagrams/utils.rb
@@ -55,8 +55,17 @@ module Jekyll
         File.join(File.expand_path('../../vendor', __dir__), file)
       end
 
-      def run_jar(jar)
-        "java -Djava.awt.headless=true -jar #{jar} "
+      # Create a comand to run a jar file using the JVM.
+      #
+      # @param jar String The path to the jar file, as string.
+      # @param [jvm_opts] Hash Options passed to the JVM on startup.
+      def run_jar(jar, jvm_opts = {})
+        default_jvm_opts = {"java.awt.headless": "true"}
+        jvm_options_args = default_jvm_opts
+          .merge(jvm_opts)
+          .map {|key, value| "-D#{key}=#{value}"}
+          .join(" ")
+        "java #{jvm_options_args} -jar #{jar} "
       end
 
       def normalized_attrs(attrs, prefix:, sep: '=')

--- a/spec/jekyll-diagrams/plantuml_renderer_spec.rb
+++ b/spec/jekyll-diagrams/plantuml_renderer_spec.rb
@@ -26,6 +26,26 @@ RSpec.describe Jekyll::Diagrams::PlantUMLRenderer do
 
       it { is_expected.to match 'plantuml' }
       it { is_expected.to match '-tsvg -pipe' }
+      it { is_expected.not_to match '-Dplantuml.include.path=' }
+    end
+
+    context 'when a custom jar path is set' do      
+      subject { renderer.build_command(config) }
+      
+      let(:config) { {"jar_path" => '/foo/bar/some.jar'} }
+
+      it { is_expected.to match '/foo/bar/some.jar' }
+      it { is_expected.to match '-tsvg -pipe' }
+    end
+
+    context 'when a custom inlude path is set' do      
+      subject { renderer.build_command(config) }
+      
+      let(:config) { {"include_path" => 'buzz/include/'} }
+      
+      it { is_expected.to match '-Dplantuml.include.path=' }
+      it { is_expected.to match 'buzz/include/' }
+      it { is_expected.to match '-tsvg -pipe' }
     end
   end
 end


### PR DESCRIPTION
Plantuml is very volatile, and I had the need to use a special version of it many times.

Using includes to add macros is getting more and more common in plantuml, too -- https://github.com/stawirej/C4-PlantUML is a good example.

This adds support for both use cases of plantuml, in the way I felt suitable for my use case (an internal jekyll site for documenting our platform).

Let me know your thoughts!