### PR TITLE
Add "command" option to mermaid to specify the path to the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ digraph {
 
 #### Prerequisites
 
-Install `mermaid.cli`.
+Install `mermaid-cli`.
 
 ```bash
-$ npm install -g mermaid.cli
+$ npm install -g @mermaid-js/mermaid-cli
 ```
 
 **Notice:** You may need to install some missing libraries, follow the output of `mmdc`.

--- a/README.md
+++ b/README.md
@@ -278,12 +278,13 @@ sequenceDiagram
 
 #### Configurations
 
-| Config            | Default | Description                                                   |
-| ----------------- | ------- | ------------------------------------------------------------- |
-| `width`           | 800     | Width of the page                                             |
-| `height`          | 600     | Height of the page                                            |
-| `backgroundColor` | white   | Background color. Example: transparent, red, '#F0F0F0'        |
-| `theme`           | default | Theme of the chart, could be default, forest, dark or neutral |
+| Config             | Default | Description                                                                           |
+| ----------------- | ------- | ------------------------------------------------------------------------------------- |
+| `width`           | 800     | Width of the page                                                                     |
+| `height`          | 600     | Height of the page                                                                    |
+| `backgroundColor` | white   | Background color. Example: transparent, red, '#F0F0F0'                                |
+| `theme`           | default | Theme of the chart, could be default, forest, dark or neutral                         |
+| `command`         | mmdc    | The path to the mermaid-cli command. It uses the globally installed 'mmdc' by default |
 
 ### Nomnoml
 

--- a/lib/jekyll-diagrams/mermaid/renderer.rb
+++ b/lib/jekyll-diagrams/mermaid/renderer.rb
@@ -15,7 +15,8 @@ module Jekyll
       end
 
       def build_command(config)
-        command = +'mmdc --puppeteerConfigFile '
+        base_command = config.fetch('command', 'mmdc')
+        command = base_command + ' --puppeteerConfigFile '
         command << Utils.vendor_path('mermaid_puppeteer_config.json')
 
         CONFIGURATIONS.each do |conf|

--- a/spec/jekyll-diagrams/mermaid_renderer_spec.rb
+++ b/spec/jekyll-diagrams/mermaid_renderer_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe Jekyll::Diagrams::MermaidRenderer do
 
       it { is_expected.to match 'mmdc --puppeteerConfigFile' }
     end
+
+    context 'when command_path is set' do
+      subject { renderer.build_command(config) }
+
+      let(:config) { {'command' => '/path/to/command'} }
+
+      it { is_expected.to match '/path/to/command --puppeteerConfigFile' }
+    end
   end
 end


### PR DESCRIPTION
This is useful if you don't want to install mermaid-cli globally, but locally. In that case one could set the command to for example "'./node_modules/@mermaid-js/mermaid-cli/index.bundle.js'"